### PR TITLE
Include the filename in the resolve() die message

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Path::Class.
 
+{{$NEXT}
+ - resolve() now includes the name of the non-existent file in the error
+   message. [Karen Etheridge]
+
 0.25  Wed Feb 15 20:55:30 CST 2012
 
  - resolve() now croak()s instead of die()s on non-existent file. [Danijel Tašov]

--- a/lib/Path/Class/Entity.pm
+++ b/lib/Path/Class/Entity.pm
@@ -61,7 +61,7 @@ sub cleanup {
 
 sub resolve {
   my $self = shift;
-  Carp::croak($!) unless -e $self;  # No such file or directory
+  Carp::croak($! . " $self") unless -e $self;  # No such file or directory
   my $cleaned = $self->new( scalar Cwd::realpath($self->stringify) );
 
   # realpath() always returns absolute path, kind of annoying


### PR DESCRIPTION
It's frustrating not knowing which file is being referred to in the error message; resolve() now includes it.  (Most other uses of $! already added the filename.)
