### PR TITLE
Skip traverse_if tests if running as root

### DIFF
--- a/t/06-traverse_filt.t
+++ b/t/06-traverse_filt.t
@@ -5,7 +5,12 @@ use Cwd;
 use Test::More;
 use File::Temp qw(tempdir);
 
-plan tests => 4;
+if ( $> == 0 ) {
+  plan skip_all => 'Root sees all and knows all';
+}
+else {
+  plan tests => 4;
+}
 
 use_ok 'Path::Class';
 


### PR DESCRIPTION
These tests fail when running as root, because root can access the paths despite file permissions.
