### PR TITLE
Replace unicode MINUS SIGN with ascii HYPHEN-MINUS

### DIFF
--- a/lib/Path/Class/File.pm
+++ b/lib/Path/Class/File.pm
@@ -360,7 +360,7 @@ the MODE argument of C<open()> is accepted here).  Just make sure it's
 a I<reading> mode.
 
   my @lines = $file->slurp(iomode => ':crlf');
-  my $lines = $file->slurp(iomode => '<:encoding(UTF−8)');
+  my $lines = $file->slurp(iomode => '<:encoding(UTF-8)');
 
 The default C<iomode> is C<r>.
 


### PR DESCRIPTION
Perldoc shows a pod error:
  Hey! The above document had some coding errors, which are explained below:
  Non-ASCII character seen before =encoding in ''<:encoding(UTF−8)');'. Assuming UTF-8

Trying the verbatim code throws an exception:
  Cannot find encoding "UTF−8" at /home/rando/perl5/perlbrew/perls/5.14.2-st/lib/5.14.2/x86_64-linux-thread-multi/IO/File.pm line 182.
