### PR TITLE
Fixes for copy_to and move_to methods

### DIFF
--- a/lib/Path/Class/File.pm
+++ b/lib/Path/Class/File.pm
@@ -482,13 +482,16 @@ Returns the class which should be used to create directory objects.
 
 Generally overridden whenever this class is subclassed.
 
-=item $file->copy_to( $dest );
+=item $copy = $file->copy_to( $dest );
 
-Copies the C<$file> to C<$dest>.
+Copies the C<$file> to C<$dest>. It returns a L<Path::Class::File>
+object when successful, C<undef> otherwise.
 
-=item $file->move_to( $dest );
+=item $moved = $file->move_to( $dest );
 
-Moves the C<$file> to C<$dest>.
+Moves the C<$file> to C<$dest>, and updates C<$file> accordingly.
+
+It returns C<$file> is successful, C<undef> otherwise.
 
 =back
 


### PR DESCRIPTION
- The destination for copy_to and move_to is stringified
- Updated POD about to clarify the behaviour of these methods
- Whitespace cleanup
