### PR TITLE
Don't convert file into directory in subsumes()

### DIFF
--- a/lib/Path/Class/Dir.pm
+++ b/lib/Path/Class/Dir.pm
@@ -270,7 +270,7 @@ sub subsumes {
   my ($self, $other) = @_;
   die "No second entity given to subsumes()" unless $other;
   
-  $other = $self->new($other) unless UNIVERSAL::isa($other, __PACKAGE__);
+  $other = $self->new($other) unless UNIVERSAL::isa($other, "Path::Class::Entity");
   $other = $other->dir unless $other->is_dir;
   
   if ($self->is_absolute) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -7,7 +7,7 @@ use strict;
 use Path::Class;
 use Cwd;
 
-plan tests => 68;
+plan tests => 70;
 ok(1);
 
 my $file1 = Path::Class::File->new('foo.txt');
@@ -147,4 +147,6 @@ ok $file->parent, '/foo/baz';
   ok dir('/foo/bar')->subsumes('foo/bar'), 0;
   ok dir('/foo/bar')->subsumes('/foo/baz'), 0;
   ok dir('/')->subsumes('/foo/bar'), 1;
+  ok dir('/')->subsumes(file('/foo')), 1;
+  ok dir('/foo')->subsumes(file('/foo')), 0;
 }


### PR DESCRIPTION
Logically, even though both can't exist at the same time, the
directory /foo does not subsume the file /foo.
