### PR TITLE
spew_lines with test

### DIFF
--- a/lib/Path/Class/File.pm
+++ b/lib/Path/Class/File.pm
@@ -130,6 +130,23 @@ sub spew {
     return;
 }
 
+sub spew_lines {
+    my $self = shift;
+    my %args = splice( @_, 0, @_-1 );
+
+    my $content = $_[0];
+
+    # If content is an array ref, appends $/ to each element of the array.
+    # Otherwise, if it is a simple scalar, just appends $/ to that scalar.
+
+    $content
+        = ref( $content ) eq 'ARRAY'
+        ? [ map { $_, $/ } @$content ]
+        : "$content$/";
+
+    return $self->spew( %args, $content );
+}
+
 sub remove {
   my $file = shift->stringify;
   return unlink $file unless -e $file; # Sets $! correctly
@@ -449,6 +466,15 @@ opening the file, just like L</slurp> supports.
   $file->spew(iomode => '>:raw', $content);
 
 The default C<iomode> is C<w>.
+
+=item $file->spew_lines( $content );
+
+Just like C<spew>, but, if $content is a plain scalar, appends $/
+to it, or, if $content is an array ref, appends $/ to each element
+of the array.
+
+Can also take an C<iomode> parameter like C<spew>. Again, the
+default C<iomode> is C<w>.
 
 =item $file->traverse(sub { ... }, @args)
 

--- a/t/03-filesystem.t
+++ b/t/03-filesystem.t
@@ -2,7 +2,7 @@ use strict;
 use Test::More;
 use File::Temp qw(tmpnam tempdir);
 
-plan tests => 101;
+plan tests => 103;
 
 use_ok 'Path::Class';
 
@@ -190,6 +190,20 @@ SKIP: {
     my $content = $file->slurp( iomode => '<:raw');
 
     is( $content, "Line1\r\nLine2" );
+
+    $file->remove;
+    ok not -e $file;
+}
+
+{
+    my $file = file('t', 'spew_lines');
+    $file->remove() if -e $file;
+    $file->spew_lines( iomode => '>:raw', "Line1" );
+    $file->spew_lines( iomode => '>>', [qw/Line2 Line3/] );
+
+    my $content = $file->slurp( iomode => '<:raw');
+
+    is( $content, "Line1$/Line2$/Line3$/" );
 
     $file->remove;
     ok not -e $file;


### PR DESCRIPTION
This PR creates a new method called `spew_lines` - it's just like `spew`, but if a plain scalar is passed, it appends $/ to that scalar. Otherwise, if an array ref is passed, appends $/ to each element of the array.

If `spew` is the opposite of `slurp`, `spew_lines` would be the opposite of `slurp( chomp => 1 )`

Documentation and a test are included.
