### PR TITLE
Methods to get filename without extension, extension without filename etc.

### DIFF
--- a/lib/Path/Class/File.pm
+++ b/lib/Path/Class/File.pm
@@ -84,23 +84,20 @@ sub with_suffix {
     my ( $self, $suffix ) = @_;
     $suffix = q{} unless defined $suffix;
 
-    # We can't do $self->dir->file( $self->stem . $suffix )
-    # because we would get an extra leading'./'
-    # if the original dir part was empty!
-    my @components = $self->components;
-
     # Lookahead for non-period character to make sure that
     # we don't prepend any period in case someone passes an empty string!
     $suffix =~ s{\A(?=[^.])}{.};
-    $components[-1] = $self->stem . $suffix;
-    return $self->new( @components );
+    my $basename = $self->stem . $suffix;
+    return $self->new( $basename ) unless defined $self->{dir};
+    return $self->new($self->dir->components, $basename);
 }
+
+*with_extension = \&with_suffix;
 
 sub basefile {
     my ( $self ) = @_;
     return $self->new( $self->basename );
 }
-
 
 sub open  { IO::File->new(@_) }
 
@@ -364,18 +361,18 @@ with the last period (U+002E) and whatever follows it (if any) removed.
 
 =item $file->suffix
 
-=item $file->extension
-
 Returns whatever comes after the last period (U+002E) in the filename.
 
 Returns C<< undef >> if there is no period in the filename,
 and the empty string if the filename ends in a period.
 
-C<< extension >> is an alias for C<< suffix >>.
+=item $file->extension
+
+An alias for C<< suffix >>.
 
 =item my $other_file = $file->with_suffix($other_suffix);
 
-Syntactic sugar for
+An abbreviation of
 
   my $other_file = $file->dir->file( $file->stem . '.' . $other_suffix );
   
@@ -385,6 +382,10 @@ Moreover you will get correct results regardless whether
 $other_suffix is supplied with or without a leading period,
 and without an argument, or with an empty string/undef argument
 $other_file will have neither period nor extension.
+
+=item my $other_file = $file->with_extension($other_extension);
+
+An alias for C<< with_suffix >>.
 
 =item my $file_witout_dirs = $file->basefile;
 

--- a/t/08-stem.t
+++ b/t/08-stem.t
@@ -1,19 +1,18 @@
 #!/usr/bin/perl
 
-use Test::More tests => 40;
+use Test::More tests => 33;
 use Path::Class qw[ file dir ];
 
 my $dir   = dir( qw[ path to some ] );
-my %data = (
-    perl  => +{ file => $dir->file( 'file.pl' ),  suffix => '.pl',  extension => 'pl' },
-    pod   => +{ file => $dir->file( 'file.pod' ), suffix => '.pod', extension => 'pod' },
-    bare  => +{ file => $dir->file( 'file' ),     suffix => '',     extension => undef },
-    dotty => +{ file => $dir->file( 'file.' ),    suffix => '.',    extension => '' },
-    double =>
-      +{ file => $dir->file( 'file.foo.bar' ), stem => 'file.foo', suffix => '.bar', extension => 'bar' },
+my @data = (
+    +{ file => $dir->file( 'file.pl' ),  suffix => '.pl',  extension => 'pl' },                             # perl
+    +{ file => $dir->file( 'file.pod' ), suffix => '.pod', extension => 'pod' },                            # pod
+    +{ file => $dir->file( 'file' ),     suffix => '',     extension => undef },                            # bare
+    +{ file => $dir->file( 'file.' ),    suffix => '.',    extension => '' },                               # dotty
+    +{ file => $dir->file( 'file.foo.bar' ), stem => 'file.foo', suffix => '.bar', extension => 'bar' },    # double
 );
 
-while ( my( $id => $data ) = each %data ) {
+for my $data ( @data ) {
     my $basename = $data->{file}->basename;
     my $file = $data->{file};
     my $stem = $data->{stem} || 'file';
@@ -25,9 +24,15 @@ while ( my( $id => $data ) = each %data ) {
     for my $suf ( qw[ pl .pl ] ) {
         is $file->with_suffix( $suf ), $dir->file("$stem.pl"), "resuffix $file with $suf";
     }
-    my $basefile = $file->basefile;
-    isa_ok $basefile, ref($file), "class of $basename";
-    is $basefile, $basename, "basefile eq $basename";
 }
+{
+    my $file = $dir->file( 'quux.foo' );
+    my $basename = $file->basename;
+    my $basefile = $file->basefile;
+    isa_ok $basefile, ref($file), 'class of basefile';
+    is $basefile, $basename, 'basefile eq basename';
+    is $basefile->with_suffix('bar'), 'quux.bar', 'basefile with suffix';
+}
+
 
 done_testing;

--- a/t/08-stem.t
+++ b/t/08-stem.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+use Test::More tests => 40;
+use Path::Class qw[ file dir ];
+
+my $dir   = dir( qw[ path to some ] );
+my %data = (
+    perl  => +{ file => $dir->file( 'file.pl' ),  suffix => '.pl',  extension => 'pl' },
+    pod   => +{ file => $dir->file( 'file.pod' ), suffix => '.pod', extension => 'pod' },
+    bare  => +{ file => $dir->file( 'file' ),     suffix => '',     extension => undef },
+    dotty => +{ file => $dir->file( 'file.' ),    suffix => '.',    extension => '' },
+    double =>
+      +{ file => $dir->file( 'file.foo.bar' ), stem => 'file.foo', suffix => '.bar', extension => 'bar' },
+);
+
+while ( my( $id => $data ) = each %data ) {
+    my $basename = $data->{file}->basename;
+    my $file = $data->{file};
+    my $stem = $data->{stem} || 'file';
+    is $file->stem, $stem, "stem of '$basename'";
+    for my $suf ( qw[ suffix extension ] ) {
+        is $file->$suf, $data->{extension}, "$suf of $basename";
+    }
+    is $file->stem . $data->{suffix}, $basename, "roundtrip $basename";
+    for my $suf ( qw[ pl .pl ] ) {
+        is $file->with_suffix( $suf ), $dir->file("$stem.pl"), "resuffix $file with $suf";
+    }
+    my $basefile = $file->basefile;
+    isa_ok $basefile, ref($file), "class of $basename";
+    is $basefile, $basename, "basefile eq $basename";
+}
+
+done_testing;


### PR DESCRIPTION
Ken, we talked about this over email a long while ago.

This is my first pull request ever, so please bear with me if I'm doing it all wrong!

This adds methods for:

*   `stem`: getting the filename (basename) without the extension.

*   `suffix`/`extension`: getting the extension without the filename or directories.

*   `with_suffix`/`with_extension`: getting the original directory and filename with another suffix.

*   `basefile`: getting the basename as a Path::Class::File object.

We discussed using the linguistic terms 'stem' and 'suffix' on email.
I added aliases with 'extension' as well.

`suffix` returns the extension without a dot if there was a dot and an extension,
an empty string if there was a dot but no extension, and
undef if there was neither a dot nor an extension.
This is of course a side effect of using `my($suffix) = $file->basename =~ /\.([^.]*)?\z/;`
to get the suffix, but I think it may actually be useful, so I didn't 'normalize' the undef to an empty string.

`with_suffix` was added because it does the right thing regardless of whether you pass the new suffix with or without a leading dot.
Also unlike `$file->dir->file( $file->stem . ".newsuffix" )` it doesn't prepend a dot for the current directory if `$file` doesn't have any directory, which IMO is the Right Thing.

`basefile` was added so that you can do this without worrying whether the new suffix has a leading dot or not:

    $some_dir->file( $some_file->basefile->with_suffix($some_suffix) )

I hope you find them all useful! I'm dealing programmatically with markdown/html or code/documentation etc. files having or meant to have the same stem+/-dir on a regular basis, and I don't think I'm the only one.

/bpj
