### PR TITLE
Lazy load File::Copy and Perl::OSType

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl extension Path::Class.
 0.36
 
  - Use croak instead of die; use eval syntax instead of universal::isa (as perlcritic wishes) <viviparous>
+ - Load File::Copy and Perl::OSType only when used (copy_to, move_to) <Olivier Mengué>
 
 0.35  Sun Sep 14 21:29:07 CDT 2014
 

--- a/lib/Path/Class/File.pm
+++ b/lib/Path/Class/File.pm
@@ -7,8 +7,6 @@ use parent qw(Path::Class::Entity);
 use Carp;
 
 use IO::File ();
-use Perl::OSType ();
-use File::Copy ();
 
 sub new {
   my $self = shift->SUPER::new;
@@ -172,8 +170,10 @@ sub copy_to {
     croak "Don't know how to copy files to objects of type '".ref($self)."'";
   }
 
+  require Perl::OSType;
   if ( !Perl::OSType::is_os_type('Unix') ) {
 
+      require File::Copy;
       return unless File::Copy::cp($self->stringify, "${dest}");
 
   } else {
@@ -187,6 +187,7 @@ sub copy_to {
 
 sub move_to {
   my ($self, $dest) = @_;
+  require File::Copy;
   if (File::Copy::move($self->stringify, "${dest}")) {
 
       my $new = $self->new($dest);


### PR DESCRIPTION
`File::Copy` and `Perl::OSType` are used only for `copy_to` and `move_to`. This is a marginal use case for `Path::Class`.

So this patch delays the loading of `File::Copy` and `Perl::OSType` to the first time they are used by those methods.