### PR TITLE
Update Dir.pm

### DIFF
--- a/lib/Path/Class/Dir.pm
+++ b/lib/Path/Class/Dir.pm
@@ -28,7 +28,7 @@ sub new {
   my $s = $self->_spec;
   
   my $first = (@_ == 0     ? $s->curdir :
-	       $_[0] eq '' ? (shift, $s->rootdir) :
+	       !ref($_[0]) && $_[0] eq '' ? (shift, $s->rootdir) :
 	       shift()
 	      );
   


### PR DESCRIPTION
I ran into this issue..
https://rt.cpan.org/Public/Bug/Display.html?id=77259
The patch listed there fixes our issue.
This PR is simply that patch.

I was wondering though if you could maybe shed some light on why this issue only seems to happen sometimes?
We use Path::Class::Dir in our codebase in a bunch of places, but this issue only popped up recently.  Additionally the error only happens in certain situations that I have not been able to track down.  I tried looking at the Path::Class::Entity source to see if I could figure out why but made no headway.
So if you could also shed some light on what circumstances make $_[0] a ref instead of a scalar it would be appreciated.

Regardless though the patch does fix the issue for us.