### PR TITLE
always use canonpath on arguments to splitdir

### DIFF
--- a/lib/Path/Class/Dir.pm
+++ b/lib/Path/Class/Dir.pm
@@ -45,7 +45,7 @@ sub new {
   push @{$self->{dirs}}, map {
     Scalar::Util::blessed($_) && $_->isa("Path::Class::Dir")
       ? @{$_->{dirs}}
-      : $s->splitdir($_)
+      : $s->splitdir( $s->canonpath($_) )
   } @_;
 
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -7,7 +7,7 @@ use strict;
 use Path::Class;
 use Cwd;
 
-plan tests => 70;
+plan tests => 78;
 ok(1);
 
 my $file1 = Path::Class::File->new('foo.txt');
@@ -22,6 +22,13 @@ ok $file2->is_absolute, '';
 ok $file2->dir, 'dir';
 ok $file2->basename, 'bar.txt';
 
+my $file3 = file('dir', 'foo/bar.txt');
+ok $file3, 'dir/foo/bar.txt';
+ok $file3->is_absolute, '';
+ok $file3->dir, 'dir/foo';
+ok $file3->dir->parent, 'dir';
+ok $file3->basename, 'bar.txt';
+
 my $dir = dir('tmp');
 ok $dir, 'tmp';
 ok $dir->is_absolute, '';
@@ -30,6 +37,11 @@ ok $dir->basename, 'tmp';
 my $dir2 = dir('/tmp');
 ok $dir2, '/tmp';
 ok $dir2->is_absolute, 1;
+
+my $dir3 = dir('/tmp', 'foo/');
+ok $dir3, '/tmp/foo';
+ok $dir3->parent, '/tmp';
+ok $dir3->is_absolute, 1;
 
 my $cat = file($dir, 'foo');
 ok $cat, 'tmp/foo';


### PR DESCRIPTION
If splitdir is passed an argument with a trailing '/' it will return the
empty string as the final component.  Calling parent on a Dir object
with the trailing empty component will return a new Dir object just
without the trailing empty string, which is equivalent to the original
rather than the actual parent.