### PR TITLE
Fix a few bugs in contains/subsumes, and doc update

### DIFF
--- a/lib/Path/Class/Dir.pm
+++ b/lib/Path/Class/Dir.pm
@@ -311,8 +311,11 @@ sub contains {
   Carp::croak "No second entity given to contains()" unless defined $other;
   return unless -d $self and (-e $other or -l $other);
 
-  $other = $self->new($other) unless eval{$other->isa("Path::Class::Entity")};
-  $other->resolve;
+  # We're going to resolve the path, and don't want side effects on the objects
+  # so clone them.  This also handles strings passed as $other.
+  $self= $self->new($self)->resolve;
+  $other= $self->new($other)->resolve;
+  
   return $self->subsumes($other);
 }
 

--- a/lib/Path/Class/Dir.pm
+++ b/lib/Path/Class/Dir.pm
@@ -269,9 +269,9 @@ sub next {
 sub subsumes {
   Carp::croak "Too many arguments given to subsumes()" if $#_ > 2;
   my ($self, $other) = @_;
-  Carp::croak( "No second entity given to subsumes()" ) unless $other;
+  Carp::croak( "No second entity given to subsumes()" ) unless defined $other;
 
-  $other = $self->new($other) unless eval{$other->isa( "Path::Class::Entity")} ;
+  $other = $self->new($other) unless eval{$other->isa( "Path::Class::Entity")};
   $other = $other->dir unless $other->is_dir;
 
   if ($self->is_absolute) {
@@ -308,7 +308,7 @@ sub subsumes {
 sub contains {
   Carp::croak "Too many arguments given to contains()" if $#_ > 2;
   my ($self, $other) = @_;
-  Carp::croak "No second entity given to contains()" unless $other;
+  Carp::croak "No second entity given to contains()" unless defined $other;
   return unless -d $self and (-e $other or -l $other);
 
   $other = $self->new($other) unless eval{$other->isa("Path::Class::Entity")};

--- a/lib/Path/Class/Dir.pm
+++ b/lib/Path/Class/Dir.pm
@@ -586,15 +586,17 @@ assume it's a directory.
   # Examples:
   dir('foo/bar' )->subsumes(dir('foo/bar/baz'))  # True
   dir('/foo/bar')->subsumes(dir('/foo/bar/baz')) # True
+  dir('foo/..')->subsumes(dir('foo/../bar))      # True
   dir('foo/bar' )->subsumes(dir('bar/baz'))      # False
   dir('/foo/bar')->subsumes(dir('foo/bar'))      # False
+  dir('foo/..')->subsumes(dir('bar'))            # False! Use C<contains> to resolve ".."
 
 
 =item $boolean = $dir->contains($other)
 
 Returns true if this directory actually contains C<$other> on the
 filesystem.  C<$other> doesn't have to be a direct child of C<$dir>,
-it just has to be subsumed.
+it just has to be subsumed after both paths have been resolved.
 
 =item $foreign = $dir->as_foreign($type)
 

--- a/t/03-filesystem.t
+++ b/t/03-filesystem.t
@@ -231,17 +231,29 @@ SKIP: {
   ok  $cur->subsumes(dir("foo"));
   ok  $cur->subsumes(dir("foo", "..", "bar"));
   ok !$cur->subsumes("..");
+  ok  $cur->subsumes("0");
 }
 
 {
   # Some edge cases with updir
   my $c = dir();
-  ok  $c->contains(dir());
-  ok  $c->contains(dir("t"));
-  ok !$c->contains(dir(".."));
-  ok !$c->contains(dir("t", "..", "foo"));
-  ok  $c->contains(dir("t", ".."));
-  ok !$c->contains(dir("t", "..", ".."));
+  ok  $c->contains(dir()),                 ". contains .";
+  ok  $c->contains(dir("t")),              ". contains t";
+  ok !$c->contains(dir("..")),             ". does not contain ..";
+  ok !$c->contains(dir("t", "..", "foo")), ". does not contains non-existent ./foo";
+  ok  $c->contains(dir("t", "..", "t")),   ". contains t/../t";
+  ok  $c->contains(dir("t", "..")),        ". contains t/..";
+  ok !$c->contains(dir("t", "..", "..")),  ". does not contain t/../..";
+  ok  $c->contains(dir("..", ($c->absolute->components)[-1])), "to .. and back";
+  
+  $c= dir("t","..");
+  ok  $c->contains(dir("t")), "./t/../ contains t";
+  
+  $c= dir("t","..","t","..","t");
+  my $other= dir("t","..","t","03-filesystem.t");
+  ok  $c->contains($other),            "./t/../t/../t contains t/03-filesystem.t";
+  is( ($other->components)[-3], '..',  "no side effect from contains()" );
+  is( ($c->components)[-2], '..',      "no side effect from contains()" );
 }
 
 {


### PR DESCRIPTION
Fixes the following cases:
  * contains() on indirect path vs indirect path
  * subsumes() with a filename that evaluates false, like "0"
  * possible un-wanted side effect of resolving the argument passed to contains()

and adds documentation and test cases for the above.