### PR TITLE
Proposed fix to warning about "Wide character in print".

### DIFF
--- a/lib/Path/Class/File.pm
+++ b/lib/Path/Class/File.pm
@@ -114,6 +114,7 @@ sub spew {
 
     my $iomode = $args{iomode} || 'w';
     my $fh = $self->open( $iomode ) or croak "Can't write to $self: $!";
+    binmode $fh, ':utf8';
 
     if (ref($_[0]) eq 'ARRAY') {
         # Use old-school for loop to avoid copying.


### PR DESCRIPTION
Hi @kenahoo 

Please review the PR.
I encountered the following warnings while building a dist on my local machine:

Wide character in print at /usr/local/share/perl/5.18.2/Path/Class/File.pm line 126.

I propose the above PR to fix the warning.

Many Thanks.
Best Regards,
Mohammad S Anwar