### PR TITLE
Include META.json in releases

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Path::Class.
 
+0.38  Sat Aug 13 21:33:23 CDT 2016
+
+ - Added [MetaJSON] to dist.ini, so release includes META.json
+
 0.37  Sat Aug 13 21:33:23 CDT 2016
 
  - Doc update for contains/subsumes [1916528]

--- a/cpanfile
+++ b/cpanfile
@@ -15,7 +15,7 @@ requires "parent" => "0";
 requires "strict" => "0";
 
 on 'build' => sub {
-  requires "Module::Build" => "0.3601";
+  requires "Module::Build" => "0.28";
 };
 
 on 'test' => sub {
@@ -25,6 +25,6 @@ on 'test' => sub {
 };
 
 on 'configure' => sub {
-  requires "ExtUtils::MakeMaker" => "6.30";
-  requires "Module::Build" => "0.3601";
+  requires "ExtUtils::MakeMaker" => "0";
+  requires "Module::Build" => "0.28";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Path-Class
-version = 0.37
+version = 0.38
 author  = Ken Williams <kwilliams@cpan.org>
 license = Perl_5
 copyright_holder = Ken Williams
@@ -9,6 +9,7 @@ copyright_holder = Ken Williams
 [PruneCruft]
 [ManifestSkip]
 [MetaYAML]
+[MetaJSON]
 [License]
 [Readme]
 [ExtraTests]


### PR DESCRIPTION
Hi Ken,

This just adds [MetaJSON] to `dist.ini`, so that releases will include a META.json file. The JSON file gives more fidelity to dependency metadata, compared with the YAML file.

Cheers,
Neil
